### PR TITLE
Update wgsl shaders

### DIFF
--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -1,15 +1,15 @@
 // Vertex shader bindings
 
 struct VertexOutput {
-    [[location(0)]] tex_coord: vec2<f32>;
-    [[location(1)]] color: vec4<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>;
+    @location(1) color: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
 };
 
 struct Locals {
     screen_size: vec2<f32>;
 };
-[[group(0), binding(0)]] var<uniform> r_locals: Locals;
+@group(0) @binding(0) var<uniform> r_locals: Locals;
 
 fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     let cutoff = srgb < vec3<f32>(10.31475);
@@ -18,11 +18,11 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -46,11 +46,11 @@ fn vs_main(
     return out;
 }
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_conv_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -76,10 +76,10 @@ fn vs_conv_main(
 
 // Fragment shader bindings
 
-[[group(1), binding(0)]] var r_tex_color: texture_2d<f32>;
-[[group(1), binding(1)]] var r_tex_sampler: sampler;
+@group(1) @binding(0) var r_tex_color: texture_2d<f32>;
+@group(1) @binding(1) var r_tex_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
 }

--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -1,13 +1,13 @@
 // Vertex shader bindings
 
 struct VertexOutput {
-    @location(0) tex_coord: vec2<f32>;
-    @location(1) color: vec4<f32>;
-    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 struct Locals {
-    screen_size: vec2<f32>;
+    screen_size: vec2<f32>,
 };
 @group(0) @binding(0) var<uniform> r_locals: Locals;
 
@@ -18,14 +18,14 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-@stage(vertex)
+@vertex
 fn vs_main(
     @location(0) a_pos: vec2<f32>,
     @location(1) a_tex_coord: vec2<f32>,
     @location(2) a_color: u32,
 ) -> VertexOutput {
-    var out: VertexOutput;
-    out.tex_coord = a_tex_coord;
+    var vertex_output: VertexOutput;
+    vertex_output.tex_coord = a_tex_coord;
 
     // [u8; 4] SRGB as u32 -> [r, g, b, a]
     let color = vec4<f32>(
@@ -34,26 +34,26 @@ fn vs_main(
         f32((a_color >> 16u) & 255u),
         f32((a_color >> 24u) & 255u),
     );
-    out.color = vec4<f32>(linear_from_srgb(color.rgb), color.a / 255.0);
+    vertex_output.color = vec4<f32>(linear_from_srgb(color.rgb), color.a / 255.0);
 
-    out.position = vec4<f32>(
+    vertex_output.position = vec4<f32>(
         2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
         1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
         0.0,
         1.0,
     );
 
-    return out;
+    return vertex_output;
 }
 
-@stage(vertex)
+@vertex
 fn vs_conv_main(
     @location(0) a_pos: vec2<f32>,
     @location(1) a_tex_coord: vec2<f32>,
     @location(2) a_color: u32,
 ) -> VertexOutput {
-    var out: VertexOutput;
-    out.tex_coord = a_tex_coord;
+    var vertex_output: VertexOutput;
+    vertex_output.tex_coord = a_tex_coord;
 
     // [u8; 4] SRGB as u32 -> [r, g, b, a]
     let color = vec4<f32>(
@@ -62,16 +62,16 @@ fn vs_conv_main(
         f32((a_color >> 16u) & 255u),
         f32((a_color >> 24u) & 255u),
     );
-    out.color = vec4<f32>(color.rgba / 255.0);
+    vertex_output.color = vec4<f32>(color.rgba / 255.0);
 
-    out.position = vec4<f32>(
+    vertex_output.position = vec4<f32>(
         2.0 * a_pos.x / r_locals.screen_size.x - 1.0,
         1.0 - 2.0 * a_pos.y / r_locals.screen_size.y,
         0.0,
         1.0,
     );
 
-    return out;
+    return vertex_output;
 }
 
 // Fragment shader bindings
@@ -79,7 +79,7 @@ fn vs_conv_main(
 @group(1) @binding(0) var r_tex_color: texture_2d<f32>;
 @group(1) @binding(1) var r_tex_sampler: sampler;
 
-@stage(fragment)
-fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
+@fragment
+fn fs_main(vertex_input: VertexOutput) -> @location(0) vec4<f32> {
+    return vertex_input.color * textureSample(r_tex_color, r_tex_sampler, vertex_input.tex_coord);
 }


### PR DESCRIPTION
Changes the struct member separator from `;` to `,`, `out` to `vertex_output` and `in` to `vertex_input` since they are now reserved keywords